### PR TITLE
Add: usersテーブルにuuidカラムを追加し、URLやデザインを修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to edit_profile_path(@user), success: t('defaults.message.updated', item: t('defaults.profile'))
+      redirect_to user_path(@user), success: t('defaults.message.updated', item: t('defaults.profile'))
     else
       flash.now[:danger] = t('defaults.message.not_updated', item: t('defaults.profile'))
       render :edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -19,6 +19,6 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :description, :image, :images_cache)
+    params.require(:user).permit(:name, :uuid, :description, :image, :images_cache)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.find_by(uuid: params[:uuid])
     @posts = @user.posts.includes(:user, :items, :post_images).order(created_at: :desc)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,8 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-
+    @user.uuid ||= SecureRandom.alphanumeric(10)
+    
     if @user.save
       login(params[:user][:email], params[:user][:password])
       redirect_to root_path, success: t('.success')
@@ -25,6 +26,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :description, :image)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :description, :image, :uuid)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.uuid ||= SecureRandom.alphanumeric(10)
-    
+
     if @user.save
       login(params[:user][:email], params[:user][:password])
       redirect_to root_path, success: t('.success')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,14 +12,14 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
-  validates :name, presence: true, length: { maximum: 50 } #Twitterに準拠
+  validates :name, presence: true, length: { maximum: 50 } # Twitterに準拠
   validates :email, uniqueness: true, presence: true
   validates :password, length: { in: 8..30 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :description, length: { maximum: 200 }
-  validates :uuid, presence: true, uniqueness: true, length: { in: 4..15 } #Twitterに準拠
+  validates :uuid, presence: true, uniqueness: true, length: { in: 4..15 } # Twitterに準拠
 
   enum role: { general: 0, admin: 1 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,4 +50,8 @@ class User < ApplicationRecord
   def unbookmark(post)
     bookmark_posts.delete(post)
   end
+
+  def to_param
+    uuid
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,13 +12,14 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
-  validates :name, presence: true, length: { maximum: 20 }
+  validates :name, presence: true, length: { maximum: 50 } #Twitterに準拠
   validates :email, uniqueness: true, presence: true
   validates :password, length: { in: 8..30 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :description, length: { maximum: 200 }
+  validates :uuid, presence: true, uniqueness: true, length: { in: 4..15 } #Twitterに準拠
 
   enum role: { general: 0, admin: 1 }
 

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -9,7 +9,7 @@ aside.main-sidebar.sidebar-dark-primary.elevation-4
         = image_tag current_user.image_url(:thumb), class: 'img-circle elevation-2'
       .info
         = link_to admin_user_path(current_user), class: 'd-block' do
-          = current_user.name
+          = truncate(current_user.name, length: 20)
     nav.mt-2
       ul.nav.nav-pills.nav-sidebar.flex-column[data-widget="treeview" role="menu" data-accordion="false"]
         li.nav-item

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -24,7 +24,7 @@
             th[scope="row"]
               = t('activerecord.attributes.user.name')
             td
-              = @user.name
+              = truncate(@user.name, length: 20)
           tr
             th[scope="row"]
               = t('activerecord.attributes.user.image')

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,6 +1,6 @@
 article.media id="comment-#{comment.id}"
   figure.media-left
-    p.image.is-48x48
+    p.image.is-32x32
       = link_to user_path(comment.user), class: 'has-text-white' do
         = image_tag comment.user.image_url(:thumb), class: 'is-rounded'
   .media-content

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -6,15 +6,14 @@ article.media id="comment-#{comment.id}"
   .media-content
     .content
       p
-        strong
-          = link_to user_path(comment.user), class: 'has-text-white' do
-            = comment.user.name
+        = link_to user_path(comment.user), class: 'has-text-white' do
+          strong
+            = truncate(comment.user.name, length: 12)
+          small.has-text-grey-lighter  
+            = " @#{comment.user.uuid} "
+            = " ･ #{time_ago_in_words(comment.created_at)}"
         br
         = safe_join(comment.body.split("\n"),tag(:br))
-        br    
-        small.has-text-grey-lighter.is-size-7
-          = time_ago_in_words(comment.created_at)
-          = "前"
   .media-right
     - if current_user&.own?(comment)
       = link_to comment_path(comment), method: :delete,

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -8,7 +8,7 @@
         .control
           #post-file-upload.file.has-name.is-fullwidth
             label.file-label.is-normal
-              = f.file_field :images, multiple: true, accept: 'image/*', class: 'file-input', required: true
+              = f.file_field :images, multiple: true, accept: 'image/*', class: 'file-input'
               = f.hidden_field :image_cache
               span.file-cta
                 span.file-icon
@@ -53,7 +53,7 @@
             = b.label class: 'checkbox has-text-weight-semibold' do
               = b.check_box + " #{b.text}　"
         p.help.has-text-grey-lighter.is-size-7
-          | デスク用途に近しいものを選択してください（必須）
+          | 利用者の属性に当てはまるものを選択してください（必須）
               
   .field.is-horizontal
     .field-label.is-normal
@@ -91,7 +91,7 @@
     .field-body
       .field
         .control
-          = f.submit '投稿する', class: %w[button is-light has-text-weight-semibold is-rounded]
+          = f.submit '投稿する', class: %w[button is-light has-text-weight-semibold is-rounded], id: 'submit-button'
   hr  
   p.has-text-centered.is-size-7.has-text-grey-light
     | *記載に関してはアップデート対応予定

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -12,7 +12,7 @@
                 = image_tag post.user.image_url(:thumb), class: 'is-rounded'
             .media-content
               p.title.is-6.has-text-weight-semibold
-                = post.user.name
+                = truncate(post.user.name, length: 20)
               p.subtitle.is-6
                 = l post.created_at, format: :short
             .media-right

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -12,7 +12,7 @@
                 = image_tag post.user.image_url(:thumb), class: 'is-rounded'
             .media-content
               p.title.is-6.has-text-weight-semibold
-                = truncate(post.user.name, length: 20)
+                = truncate(post.user.name, length: 12)
               p.subtitle.is-6
                 = l post.created_at, format: :short
             .media-right

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -12,7 +12,7 @@
                 = image_tag post_3col.user.image_url(:thumb), class: 'is-rounded'
             .media-content
               p.title.is-6.has-text-weight-semibold
-                = post_3col.user.name
+                = truncate(post_3col.user.name, length: 20)
               p.subtitle.is-6
                 = l post_3col.created_at, format: :short
             .media-right

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -82,7 +82,7 @@ main
                       time
                         = l @post.created_at, format: :short
                 footer.card-footer
-                  = link_to "https://twitter.com/share?url=#{request.url}&text=#{@post.user.name}のデスクをチェック&hashtags=Buildesk,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
+                  = link_to "https://twitter.com/share?url=#{request.url}&text=#{@post.user.name}のデスクをチェック&hashtags=Buildesk,mynewgear,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
                     span.icon-text
                       i.fab.fa-twitter
                       = 'シェアする'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -14,19 +14,9 @@ section.hero.is-small
               p.title.has-text-weight-bold.is-5
                 = link_to user_path(@post.user), class: 'has-text-white' do
                   = truncate(@post.user.name, length: 15)
-              p.subtitle.is-7.has-text-light
-                = t('activerecord.attributes.post.category_ids')
-                = '：'
-                = link_to category_path(@post.categories[0].name) do
-                  = @post.categories[0].name
-                - if @post.categories[1].present?
-                  = ' / '
-                  = link_to category_path(@post.categories[1].name) do
-                    = @post.categories[1].name
-                - if @post.categories[2].present?
-                  = ' / '
-                  = link_to category_path(@post.categories[2].name) do
-                    = @post.categories[2].name
+              p.subtitle.is-7
+                = link_to user_path(@post.user), class: 'has-text-grey-lighter' do
+                  = "@#{@post.user.uuid}"
 
 main
   section.columns.is-centered.is-marginless
@@ -34,28 +24,28 @@ main
       .container
         .tile.is-ancestor
           .tile.is-7.is-parent.is-vertical
-            .tile
+            /.tile
               .tile.is-vertical
-                .tile.is-child
-                  figure.image.is-4by3
-                    = image_tag @post.post_images.first.image_url(:main)
-                / デスクトップ表示用コメント欄
-                .tile.is-child.is-hidden-mobile
-                  p.title.has-text-weight-bold.is-5
-                    = t('activerecord.models.comment')
-                  #desktop_comments
-                    = render @comments
-                    - if logged_in?
-                      .media
-                        figure.media-left
-                          p.image.is-48x48
-                            = image_tag current_user.image_url(:thumb), class: 'is-rounded'
-                        .media-content
-                          = render 'comments/form', { post: @post, comment: @comment }
-                    - else
-                      br
-                        p.has-text-centered
-                          | ログインするとコメントできます
+            .tile.is-child
+              figure.image.is-4by3
+                = image_tag @post.post_images.first.image_url(:main)
+            / デスクトップ表示用コメント欄
+            .tile.is-child.is-hidden-mobile
+              p.title.has-text-weight-bold.is-5
+                = t('activerecord.models.comment')
+              #desktop_comments
+                = render @comments
+                - if logged_in?
+                  .media
+                    figure.media-left
+                      p.image.is-48x48
+                        = image_tag current_user.image_url(:thumb), class: 'is-rounded'
+                    .media-content
+                      = render 'comments/form', { post: @post, comment: @comment }
+                - else
+                  br
+                    p.has-text-centered
+                      | ログインするとコメントできます
 
           .tile.is-parent.is-vertical
             .tile.is-child
@@ -72,15 +62,30 @@ main
                       = render 'crud_menus', post: @post
                 .card-content
                   .content
+                    small.has-text-grey-light
+                      = t('activerecord.attributes.post.category_ids')
+                      = '：'
+                      = link_to category_path(@post.categories[0].name) do
+                        = @post.categories[0].name
+                      - if @post.categories[1].present?
+                        = ' / '
+                        = link_to category_path(@post.categories[1].name) do
+                          = @post.categories[1].name
+                      - if @post.categories[2].present?
+                        = ' / '
+                        = link_to category_path(@post.categories[2].name) do
+                          = @post.categories[2].name
+                    hr
                     p
                       - if @post.body.present?
                         = safe_join(@post.body.split("\n"),tag(:br))
                       - else
                         p.has-text-centered
                           | No comment..
+                    hr
                     small.has-text-grey-light
                       time
-                        = l @post.created_at, format: :short
+                        = l @post.created_at, format: :long
                 footer.card-footer
                   = link_to "https://twitter.com/share?url=#{request.url}&text=#{@post.user.name}のデスクをチェック&hashtags=Buildesk,mynewgear,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
                     span.icon-text

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -13,7 +13,7 @@ section.hero.is-small
             .media-content
               p.title.has-text-weight-bold.is-5
                 = link_to user_path(@post.user), class: 'has-text-white' do
-                  = @post.user.name
+                  = truncate(@post.user.name, length: 15)
               p.subtitle.is-7.has-text-light
                 = t('activerecord.attributes.post.category_ids')
                 = '：'

--- a/app/views/profiles/_form.html.slim
+++ b/app/views/profiles/_form.html.slim
@@ -5,8 +5,17 @@
       = f.label :name
     .control.has-icons-left.has-icons-right
       = f.text_field :name, class: 'input'
-      span.icon.is-small.is-left
+      span.icon.is-left
         i.fas.fa-user
+      span.icon
+
+  .field
+    label.label
+      = f.label :uuid
+    .control.has-icons-left.has-icons-right
+      = f.text_field :uuid, class: 'input'
+      span.icon.is-left.has-text-weight-bold
+        | ＠
       span.icon
 
   .field

--- a/app/views/profiles/_form.html.slim
+++ b/app/views/profiles/_form.html.slim
@@ -44,3 +44,5 @@
   .field.is-grouped
     .control
       = f.submit class: %w[button is-light has-text-weight-semibold is-rounded is-small]
+    .control
+      = link_to 'キャンセル', :back, class: %w[button is-dark has-text-weight-semibold is-rounded is-small]

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,7 +14,7 @@ header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation
         = link_to '新規投稿', new_post_path, class: 'navbar-item', data: { turbolinks: false }
         .navbar-item.has-dropdown.is-hoverable
           a.navbar-link
-            = current_user.name
+            = truncate(current_user.name, length: 12)
           .navbar-dropdown.is-right
             = link_to 'マイページ', user_path(current_user.id), class: 'navbar-item', data: { turbolinks: false }
             = link_to 'プロフィール編集', edit_profile_path, class: 'navbar-item', data: { turbolinks: false }

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -16,7 +16,7 @@ header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation
           a.navbar-link
             = truncate(current_user.name, length: 12)
           .navbar-dropdown.is-right
-            = link_to 'マイページ', user_path(current_user.id), class: 'navbar-item', data: { turbolinks: false }
+            = link_to 'マイページ', user_path(current_user), class: 'navbar-item', data: { turbolinks: false }
             = link_to 'プロフィール編集', edit_profile_path, class: 'navbar-item', data: { turbolinks: false }
             hr.navbar-divider
             = link_to t('defaults.logout'), logout_path, class: 'navbar-item', method: :delete
@@ -40,7 +40,7 @@ nav.navbar.is-dark.is-fixed-bottom[role="navigation"]
       i.fa.fa-bookmark
       p.is-size-7
         | List
-    = link_to user_path(current_user.id), class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
+    = link_to user_path(current_user), class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
       i.fa.fa-user
       p.is-size-7
         | Mypage 

--- a/app/views/user_sessions/_form.html.slim
+++ b/app/views/user_sessions/_form.html.slim
@@ -1,12 +1,12 @@
 = form_with url: login_path, method: :post, local: true do |f|
   .field
     p.control.has-icons-left
-      = f.text_field :email, class: 'input', placeholder: User.human_attribute_name(:email)
+      = f.text_field :email, class: 'input', placeholder: User.human_attribute_name(:email), required: true
       span.icon.is-small.is-left
         i.fa.fa-envelope
   .field
     p.control.has-icons-left
-      = f.password_field :password, class: 'input', placeholder: User.human_attribute_name(:password)
+      = f.password_field :password, class: 'input', placeholder: User.human_attribute_name(:password), required: true
       span.icon.is-small.is-left
         i.fa.fa-lock
   .field

--- a/app/views/user_sessions/new.html.slim
+++ b/app/views/user_sessions/new.html.slim
@@ -1,6 +1,6 @@
 - set_meta_tags title: t('.title')
 
-main.columns.is-centered.section
+main.columns.is-centered.section.is-marginless
   .column.is-one-third
     .container.content.box
       h1.title.has-text-centered.is-size-6 ログインまたは登録

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -8,10 +8,10 @@
       = f.input :email, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
   .field
     .control
-      = f.input :password, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
+      = f.input :password, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false, required: true
   .field
     .control
-      = f.input :password_confirmation, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false
+      = f.input :password_confirmation, label_html: { class: 'label' }, input_html: { class: 'input' }, error: false, required: true
   .field
     .control
       = f.button :submit, class: %w[has-text-weight-bold button is-success is-fullwidth]

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,6 +1,6 @@
 - set_meta_tags title: t('.title')
 
-main.columns.is-centered.section
+main.columns.is-centered.section.is-marginless
   .column.is-one-third
     .container.content.box
       h1.title.has-text-centered.is-size-6 メールアドレスでユーザー登録

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,15 +11,19 @@ main.columns.is-centered.is-marginless
               .card-content
                 .media
                   .media-left
-                    figure.image.is-96x96
+                    figure.image.is-48x48
                       = image_tag @user.image.url(:thumb), class: 'is-rounded'
                   .media-content
-                    p.title.is-3.has-text-weight-bold
+                    p.title.is-4.has-text-weight-bold
                       = @user.name
                     p.subtitle.is-6
-                      = link_to 'プロフィールを編集', edit_profile_path, data: { turbolinks: false } if current_user == @user
-                    p
-                      = @user.description if @user.description.present?
+                      = "@#{@user.uuid}"
+                .content
+                  = @user.description if @user.description.present?
+                  br
+                  .has-text-right.is-size-7
+                    = link_to 'プロフィールを編集', edit_profile_path, data: { turbolinks: false } if current_user == @user
+                    
               footer.card-footer id="user-link-id-#{@user.id}"
                 - if current_user == @user
                   = link_to likes_posts_path, class: 'card-footer-item'
@@ -39,7 +43,7 @@ main.columns.is-centered.is-marginless
                       = ' Share'
           .column.is-half
             p.title.has-text-weight-bold.is-4
-              = "#{@user.name}のデスク遍歴"
+              = "#{truncate(@user.name, length: 12)}のデスク遍歴"
             .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
               - if @posts.present?
                 = render partial: 'posts/post_image', collection: @posts
@@ -47,7 +51,7 @@ main.columns.is-centered.is-marginless
                 = '投稿がありません'
             hr
             p.title.has-text-weight-bold.is-4
-              = "#{@user.name}のGear"
+              = "#{truncate(@user.name, length: 12)}のGear"
             p.subtitle.is-6
               | 投稿に紐づいたアイテム
             .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,7 +5,7 @@ main.columns.is-centered.is-marginless
     section#new_arrival
       .container
         br
-        .columns id="user-id-#{@user.id}"
+        .columns id="user-id-#{@user.uuid}"
           .column.is-two-fifths
             .card
               .card-content
@@ -24,7 +24,7 @@ main.columns.is-centered.is-marginless
                   .has-text-right.is-size-7
                     = link_to 'プロフィールを編集', edit_profile_path, data: { turbolinks: false } if current_user == @user
                     
-              footer.card-footer id="user-link-id-#{@user.id}"
+              footer.card-footer id="user-link-id-#{@user.uuid}"
                 - if current_user == @user
                   = link_to likes_posts_path, class: 'card-footer-item'
                     span.icon-text

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,7 @@ default: &default
 
 development:
   <<: *default
-  database: desktour_development
+  database: buildesk_development
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: root
@@ -34,7 +34,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: desktour_test
+  database: buildesk_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -117,11 +117,12 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = Rails.application.credentials.dig(:twitter, :key)
   config.twitter.secret = Rails.application.credentials.dig(:twitter, :secret_key)
-  config.twitter.callback_url = 'http://127.0.0.1:3000/oauth/callback?provider=twitter'
+  config.twitter.callback_url = 'https://buildesk.app/oauth/callback?provider=twitter'
   config.twitter.user_info_mapping = {
     name: 'name',
     email: 'screen_name',
     description: 'description',
+    uuid: 'screen_name',
     remote_image_url: 'profile_image_url_https'
   }
   #

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,6 +20,7 @@ ja:
         image: 'プロフィール画像'
         role: '権限'
         created_at: '作成日時'
+        uuid: 'アカウント名'
       post:
         body: 'メモ'
         area: 'ジャンル'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
 
-  resources :users, only: %i[new create show]
+  resources :users, only: %i[new create show], param: :uuid
   resources :categories, only: %i[index show], param: :name
   resources :items, only: %i[show]
   resources :posts do

--- a/db/fixtures/development/01_user.rb
+++ b/db/fixtures/development/01_user.rb
@@ -3,7 +3,8 @@
     name: Faker::Name.name,
     email: Faker::Internet.email,
     password: 'password',
-    password_confirmation: 'password'
+    password_confirmation: 'password',
+    uuid: SecureRandom.alphanumeric(10)
   )
 end
 
@@ -12,6 +13,7 @@ User.create!(
   email: 'mikasa@attack.com',
   password: 'aaaaaaaa',
   password_confirmation: 'aaaaaaaa',
+  uuid: 'mikasa210',
   role: 1
 )
 
@@ -19,5 +21,6 @@ User.create!(
   name: 'Eren',
   email: 'eren@attack.com',
   password: 'aaaaaaaa',
-  password_confirmation: 'aaaaaaaa'
+  password_confirmation: 'aaaaaaaa',
+  uuid: 'eren330'
 )

--- a/db/fixtures/development/04_post_images.rb
+++ b/db/fixtures/development/04_post_images.rb
@@ -4,9 +4,9 @@ FileUtils.rm(Dir.glob('*.*'))
 
 PostImage.seed(
   :id,
-  { image: Rails.root.join('app/public/images/20210226_233834.jpg').open, post_id: Post.find(0).id },
-  { image: Rails.root.join('app/public/images/20210226_233834.jpg').open, post_id: Post.find(1).id },
-  { image: Rails.root.join('app/public/images/20210226_233834.jpg').open, post_id: Post.find(2).id },
-  { image: Rails.root.join('app/public/images/20210226_233834.jpg').open, post_id: Post.find(3).id },
-  { image: Rails.root.join('app/public/images/20210226_233834.jpg').open, post_id: Post.find(4).id }
+  { image: Rails.root.join('public/images/20210226_233834.jpg').open, post_id: Post.find(0).id },
+  { image: Rails.root.join('public/images/20210226_233834.jpg').open, post_id: Post.find(1).id },
+  { image: Rails.root.join('public/images/20210226_233834.jpg').open, post_id: Post.find(2).id },
+  { image: Rails.root.join('public/images/20210226_233834.jpg').open, post_id: Post.find(3).id },
+  { image: Rails.root.join('public/images/20210226_233834.jpg').open, post_id: Post.find(4).id }
 )

--- a/db/migrate/20210701205310_add_uuid_to_users.rb
+++ b/db/migrate/20210701205310_add_uuid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUuidToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :uuid, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,123 +10,125 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_624_174_632) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_07_01_205310) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
-    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'item_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['item_id'], name: 'index_item_tags_on_item_id'
-    t.index ['post_id'], name: 'index_item_tags_on_post_id'
+  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_tags_on_item_id"
+    t.index ["post_id"], name: "index_item_tags_on_post_id"
   end
 
-  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name'
-    t.string 'image'
-    t.string 'price'
-    t.string 'rakuten_url'
-    t.string 'amazon_url'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'item_code', null: false
-    t.string 'maker'
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.string "price"
+    t.string "rakuten_url"
+    t.string "amazon_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "item_code", null: false
+    t.string "maker"
   end
 
-  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_likes_on_post_id'
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'area', default: 0, null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "area", default: 0, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.string "uuid", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'bookmarks', 'posts'
-  add_foreign_key 'bookmarks', 'users'
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'item_tags', 'items'
-  add_foreign_key 'item_tags', 'posts'
-  add_foreign_key 'likes', 'posts'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "item_tags", "items"
+  add_foreign_key "item_tags", "posts"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,125 +10,124 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_205310) do
-
-  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+ActiveRecord::Schema.define(version: 20_210_701_205_310) do
+  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_bookmarks_on_post_id"
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
+    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true
+  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['name'], name: 'index_categories_on_name', unique: true
   end
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "item_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["item_id"], name: "index_item_tags_on_item_id"
-    t.index ["post_id"], name: "index_item_tags_on_post_id"
+  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'item_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['item_id'], name: 'index_item_tags_on_item_id'
+    t.index ['post_id'], name: 'index_item_tags_on_post_id'
   end
 
-  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name"
-    t.string "image"
-    t.string "price"
-    t.string "rakuten_url"
-    t.string "amazon_url"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "item_code", null: false
-    t.string "maker"
+  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name'
+    t.string 'image'
+    t.string 'price'
+    t.string 'rakuten_url'
+    t.string 'amazon_url'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'item_code', null: false
+    t.string 'maker'
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_likes_on_post_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
+  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_likes_on_post_id'
+    t.index ['user_id'], name: 'index_likes_on_user_id'
   end
 
-  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "category_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
-    t.index ["category_id"], name: "index_post_categories_on_category_id"
-    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'category_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
+    t.index ['category_id'], name: 'index_post_categories_on_category_id'
+    t.index ['post_id'], name: 'index_post_categories_on_post_id'
   end
 
-  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
-    t.string "caption"
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_post_images_on_post_id"
+  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'image', null: false
+    t.string 'caption'
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_post_images_on_post_id'
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "area", default: 0, null: false
-    t.index ["user_id"], name: "index_posts_on_user_id"
+  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'area', default: 0, null: false
+    t.index ['user_id'], name: 'index_posts_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "image"
-    t.integer "role", default: 0, null: false
-    t.string "uuid", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', null: false
+    t.text 'description'
+    t.string 'image'
+    t.integer 'role', default: 0, null: false
+    t.string 'uuid', null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
 
-  add_foreign_key "bookmarks", "posts"
-  add_foreign_key "bookmarks", "users"
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "item_tags", "items"
-  add_foreign_key "item_tags", "posts"
-  add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
-  add_foreign_key "post_categories", "categories"
-  add_foreign_key "post_categories", "posts"
-  add_foreign_key "post_images", "posts"
-  add_foreign_key "posts", "users"
+  add_foreign_key 'bookmarks', 'posts'
+  add_foreign_key 'bookmarks', 'users'
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'item_tags', 'items'
+  add_foreign_key 'item_tags', 'posts'
+  add_foreign_key 'likes', 'posts'
+  add_foreign_key 'likes', 'users'
+  add_foreign_key 'post_categories', 'categories'
+  add_foreign_key 'post_categories', 'posts'
+  add_foreign_key 'post_images', 'posts'
+  add_foreign_key 'posts', 'users'
 end


### PR DESCRIPTION
## 概要

- usersテーブルにuuidカラムを追加
- ユーザー登録のバリデーションをTwitterに準拠
- uuidを利用したURL表示（``users#show``）、デザインを適用
  - uuidはアカウント名として利用

Closed #73 
Closed #46 

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした

## コメント

- テストを行なっていないので、最終的にUserモデルのスペックを作成しテストする