### PR TITLE
Fix: アプリ全体のデザイン／レイアウト崩れの修正

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -10,7 +10,7 @@ class Admin::PostsController < Admin::BaseController
 
   def destroy
     @post.destroy
-    redirect_to admin_posts_path, success: t('defaults.message.deleted', post: post.model_name.human)
+    redirect_to admin_posts_path, success: t('defaults.message.deleted', item: Post.model_name.human)
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -20,7 +20,7 @@ class Admin::UsersController < Admin::BaseController
 
   def destroy
     @user.destroy
-    redirect_to admin_root_path(@user), success: t('defaults.message.deleted', item: User.model_name.human)
+    redirect_to admin_users_path, success: t('defaults.message.deleted', item: User.model_name.human)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,10 +47,6 @@ class PostsController < ApplicationController
     redirect_to root_path, success: t('defaults.message.deleted', item: Post.model_name.human)
   end
 
-  def likes
-    @like_posts = current_user.like_posts.includes(:user, :post_images).order(created_at: :desc)
-  end
-
   def bookmarks
     @bookmark_posts = current_user.bookmark_posts.includes(:user, :post_images).order(created_at: :desc)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,6 +14,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :asc)
+    @like_count = @post.likes.count
   end
 
   def create

--- a/app/javascript/packs/bulma.js
+++ b/app/javascript/packs/bulma.js
@@ -2,10 +2,12 @@ $(document).ready(function() {
 
   // Check for click events on the navbar burger icon
   $(document).on('click', '.navbar-burger', function() {
+    // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+    $(".navbar-burger").toggleClass("is-active");
+    $(".navbar-menu").toggleClass("is-active");
+  });
 
-      // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
-      $(".navbar-burger").toggleClass("is-active");
-      $(".navbar-menu").toggleClass("is-active");
-
+  $(document).on('click', '.dropdown-trigger', function() {
+    $(".dropdown").toggleClass("is-active");
   });
 });

--- a/app/javascript/packs/bulma.js
+++ b/app/javascript/packs/bulma.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
     $(".navbar-menu").toggleClass("is-active");
   });
 
+  // 投稿の編集・削除ボタンの表示
   $(document).on('click', '.dropdown-trigger', function() {
     $(".dropdown").toggleClass("is-active");
   });

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,20 @@
-// 追加ファイル
+/* 追加ファイル */
 @import 'item_search_modal';
 @import 'bulma_override';
+
+
+/* 画像の上に文字を重ねる */
+.img-on-moji{
+  position: relative;/*相対配置*/
+  }
+ 
+.img-on-moji p {
+  position: absolute;/*絶対配置*/
+  top: 50%;
+  left: 50%;
+  -ms-transform: translate(-50%,-50%);
+  -webkit-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  margin:0;
+  padding:0;
+}

--- a/app/javascript/stylesheets/bulma_override.scss
+++ b/app/javascript/stylesheets/bulma_override.scss
@@ -38,3 +38,14 @@
 .field_with_errors {
   display: inline;
 }
+
+/* footerを常時固定 */
+.site {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.site-content {
+  flex: 1;
+}

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -9,8 +9,8 @@ class PostImage < ApplicationRecord
     image.remove!
     image.thumb.remove!
     image.main.remove!
-  rescue Excon::Errors::Error => error
-    puts "Something gone wrong"
+  rescue Excon::Errors::Error => e
+    puts 'Something gone wrong'
     false
   end
 end

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -1,4 +1,16 @@
 class PostImage < ApplicationRecord
   mount_uploader :image, PostImageUploader
   belongs_to :post
+  before_destroy :destroy_image_s3
+
+  private
+
+  def destroy_image_s3
+    image.remove!
+    image.thumb.remove!
+    image.main.remove!
+  rescue Excon::Errors::Error => error
+    puts "Something gone wrong"
+    false
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
+  before_destroy :destroy_image_s3
 
   mount_uploader :image, UserImageUploader
 
@@ -53,5 +54,15 @@ class User < ApplicationRecord
 
   def to_param
     uuid
+  end
+
+  private
+
+  def destroy_image_s3
+    image.remove!
+    image.thumb.remove!
+  rescue Excon::Errors::Error => error
+    puts "Something gone wrong"
+    false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,8 +61,8 @@ class User < ApplicationRecord
   def destroy_image_s3
     image.remove!
     image.thumb.remove!
-  rescue Excon::Errors::Error => error
-    puts "Something gone wrong"
+  rescue Excon::Errors::Error => e
+    puts 'Something gone wrong'
     false
   end
 end

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -25,7 +25,7 @@ class UserImageUploader < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    '/images/user_logo_orange.png'
+    'https://image.buildesk.app/images/user_logo_orange.png'
   end
 
   # Process files as they are uploaded:

--- a/app/views/bookmarks/_bookmark.html.slim
+++ b/app/views/bookmarks/_bookmark.html.slim
@@ -1,6 +1,6 @@
 - if current_user&.bookmarked?(post)
   = link_to bookmark_path(post), method: :delete, id: "button-bookmark-#{post.id}" do
-    i class="fas fa-bookmark"
+    i.fas.fa-bookmark.fa-lg
 - else 
   = link_to post_bookmarks_path(post), method: :post, id: "button-bookmark-#{post.id}" do
-    i class="far fa-bookmark"
+    i.far.fa-bookmark.fa-lg

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -7,6 +7,6 @@ main.columns.is-centered.is-marginless
         br
         p.title.has-text-weight-bold
           = t("category.#{@category.name}")+'のデスク'
-        .columns.is-multiline.is-variable.is-3-desktop.is-1-mobile
+        .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
           - if @posts.present?
             = render partial: 'posts/post_3col', collection: @posts

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,11 +9,12 @@ html
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   
     = display_meta_tags(default_meta_tags)
-  body
+  body.site
     - if logged_in?
       = render 'shared/header'
     - else
       = render 'shared/before_login_header'
     = render 'shared/flash_message'
-    = yield
+    .site-content
+      = yield
     = render 'shared/footer'

--- a/app/views/likes/_like.html.slim
+++ b/app/views/likes/_like.html.slim
@@ -1,6 +1,6 @@
 - if current_user&.liked?(post)
   = link_to like_path(post), method: :delete, id: "button-like-#{post.id}" do
-    i.fas.fa-heart
+    i.fas.fa-heart.fa-lg
 - else 
   = link_to post_likes_path(post), method: :post, id: "button-like-#{post.id}" do
-    i.far.fa-heart
+    i.far.fa-heart.fa-lg

--- a/app/views/posts/_crud_menus.html.slim
+++ b/app/views/posts/_crud_menus.html.slim
@@ -1,6 +1,6 @@
-span.icon
+span.icon.is-medium
   = link_to edit_post_path(post), id: "button-edit-#{post.id}" do
     i.fas.fa-pen
-span.icon
+span.icon.is-medium
   = link_to post_path(post), id: "button-delete-#{post.id}", method: :delete, data: { confirm: t('defaults.message.delete_confirm') } do
     i.fas.fa-trash

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -1,10 +1,10 @@
-.tile.is-parent
+.tile.is-parent.column.is-one-quarter
   .card
     div id="post-id-#{post.id}"
       = link_to post_path(post)
         .card-image
           figure.image
-            = image_tag post.post_images.first.image_url(:thumb), alt: 'post-img'
+            = image_tag post.post_images.first.image_url(:main), size: '1290x960', alt: 'post-img'
         .card-content
           .media
             .media-left

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -13,7 +13,7 @@
             .media-content
               p.title.is-6.has-text-weight-semibold
                 = truncate(post.user.name, length: 12)
-              p.subtitle.is-6
+              p.subtitle.is-7
                 = l post.created_at, format: :short
             .media-right
               span.tag.is-light.is-rounded

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -13,7 +13,7 @@
             .media-content
               p.title.is-6.has-text-weight-semibold
                 = truncate(post.user.name, length: 12)
-              p.subtitle.is-7
+              p.subtitle.is-6
                 = l post.created_at, format: :short
             .media-right
               span.tag.is-light.is-rounded

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -3,8 +3,8 @@
     div id="post-id-#{post_3col.id}"
       = link_to post_path(post_3col)
         .card-image
-          figure.image
-            = image_tag post_3col.post_images.first.image_url(:thumb), alt: 'post-img'
+          figure.image.is-4by3
+            = image_tag post_3col.post_images.first.image_url(:main), alt: 'post-img'
         .card-content
           .media
             .media-left
@@ -12,10 +12,10 @@
                 = image_tag post_3col.user.image_url(:thumb), class: 'is-rounded'
             .media-content
               p.title.is-6.has-text-weight-semibold
-                = truncate(post_3col.user.name, length: 20)
-              p.subtitle.is-6
+                = truncate(post_3col.user.name, length: 10)
+              p.subtitle.is-7
                 = l post_3col.created_at, format: :short
             .media-right
-              span.tag.is-light.is-rounded
+              span.tag.is-light.is-rounded.is-hidden-mobile
                 .is-6
                   = post_3col.categories[0].name

--- a/app/views/posts/bookmarks.html.slim
+++ b/app/views/posts/bookmarks.html.slim
@@ -12,4 +12,4 @@ main.columns.is-centered.is-marginless
             = render partial: 'post_image', collection: @bookmark_posts
           - else
             .section
-              | ブックマークした投稿がありません
+              | 保存した投稿がありません

--- a/app/views/posts/bookmarks.html.slim
+++ b/app/views/posts/bookmarks.html.slim
@@ -7,9 +7,10 @@ main.columns.is-centered.is-marginless
         br
         p.title.has-text-weight-bold
           = t('.title')
-        .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
-          - if @bookmark_posts.present?
+        - if @bookmark_posts.present?
+          .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
             = render partial: 'post_image', collection: @bookmark_posts
-          - else
-            .section
-              | 保存した投稿がありません
+        - else
+          br
+          p.has-text-centered
+            | 保存した投稿がありません

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -62,9 +62,11 @@ main.columns.is-centered.section.is-marginless
           .field.is-horizontal
             .field-label
             .field-body
-              .field
-                .control
+              .field.is-grouped
+                p.control
                   = f.submit '変更を保存する', class: %w[button is-light has-text-weight-semibold is-rounded]
+                p.control
+                = link_to t('defaults.back'), :back, class: 'button is-primary has-text-weight-semibold  is-rounded', data: { turbolinks: false }
 
           hr  
             p.has-text-centered.is-size-7.has-text-grey-light

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -9,6 +9,6 @@ main.columns.is-centered.is-marginless
           = t('.title')
         .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
           - if @posts.present?
-            = render partial: 'post_image', collection: @posts
+            = render partial: 'post_3col', collection: @posts
           - else
             = '投稿がありません'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -17,6 +17,16 @@ section.hero.is-small
               p.subtitle.is-7
                 = link_to user_path(@post.user), class: 'has-text-grey-lighter' do
                   = "@#{@post.user.uuid}"
+            .media-right
+              - if current_user&.own?(@post)
+                .dropdown.is-right
+                  .dropdown-trigger
+                    span.icon.is-medium
+                      i.fas.fa-angle-down.fa-lg[aria-hidden="true"]
+                  #dropdown-menu.dropdown-menu[role="menu"]
+                    .dropdown-content
+                      = link_to t('defaults.edit'), edit_post_path(@post), id: "button-edit-#{@post.id}", class: 'dropdown-item'
+                      = link_to t('defaults.delete'), post_path(@post), id: "button-delete-#{@post.id}", class: 'dropdown-item', method: :delete, data: { confirm: t('defaults.message.delete_confirm') }
 
 main
   section.columns.is-centered.is-marginless
@@ -54,12 +64,13 @@ main
                   p.card-header-title.is-size-5
                     | デスクメモ
                   .card-header-icon
-                    span.icon
-                      = render 'likes/like', post: @post
-                    span.icon
+                    span.icon.is-medium
                       = render 'bookmarks/bookmark', post: @post
-                    - if current_user&.own?(@post)
-                      = render 'crud_menus', post: @post
+                    span.icon-text
+                      span.icon.is-medium
+                        = render 'likes/like', post: @post
+                      span
+                        = @like_count
                 .card-content
                   .content
                     small.has-text-grey-light
@@ -103,7 +114,7 @@ main
                     p.has-text-centered
                       | Not registered..
           / モバイル表示用コメント欄
-          .tile.is-parent.is-hidden-desktop
+          .tile.is-parent.is-hidden-tablet
             .tile.is-child
               p.title.has-text-weight-bold.is-5
                 = t('activerecord.models.comment')

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -14,7 +14,7 @@ section.hero.is-small
               p.title.has-text-weight-bold.is-5
                 = link_to user_path(@post.user), class: 'has-text-white' do
                   = truncate(@post.user.name, length: 15)
-              p.subtitle.is-7
+              p.subtitle.is-6
                 = link_to user_path(@post.user), class: 'has-text-grey-lighter' do
                   = "@#{@post.user.uuid}"
             .media-right

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -22,7 +22,7 @@ section.hero.is-small
                 .dropdown.is-right
                   .dropdown-trigger
                     span.icon.is-medium
-                      i.fas.fa-angle-down.fa-lg[aria-hidden="true"]
+                      i.fas.fa-ellipsis-v[aria-hidden="true"]
                   #dropdown-menu.dropdown-menu[role="menu"]
                     .dropdown-content
                       = link_to t('defaults.edit'), edit_post_path(@post), id: "button-edit-#{@post.id}", class: 'dropdown-item'

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -98,7 +98,7 @@ main
                       time
                         = l @post.created_at, format: :long
                 footer.card-footer
-                  = link_to "https://twitter.com/share?url=#{request.url}&text=#{@post.user.name}のデスクをチェック&hashtags=Buildesk,mynewgear,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
+                  = link_to "https://twitter.com/share?url=#{request.url}&text=#{@post.user.name}のデスクをcheck!&hashtags=Buildesk,mynewgear,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
                     span.icon-text
                       i.fab.fa-twitter
                       = 'シェアする'

--- a/app/views/profiles/_form.html.slim
+++ b/app/views/profiles/_form.html.slim
@@ -29,11 +29,11 @@
             i.fas.fa-upload
           span.file-label
             | ファイルを選択
-    = f.hidden_field :image_cache
+    p.help.has-text-grey-lighter.is-size-7
+      | 画像は1x1でリサイズされます
     figure.image.is-96x96
-      = image_tag @user.image.url(:thumb),
-                  class: 'is-rounded',
-                  id: 'preview'
+      = image_tag(@user.image.url(:thumb), id: 'preview')
+    = f.hidden_field :image_cache
 
   .field
     label.label

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -9,6 +9,7 @@ nav.is-dark.navbar[role="navigation" aria-label="main navigation"]
         span[aria-hidden="true"] 
     #navMenu.navbar-menu
       .navbar-end
+        = link_to t('posts.index.title'), posts_path, class: 'navbar-item', data: { turbolinks: false }
         .navbar-item
           = link_to t('defaults.login'), login_path, class: 'button is-rounded is-primary is-inverted has-text-weight-semibold', data: { turbolinks: false }
 

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -2,14 +2,14 @@ nav.is-dark.navbar[role="navigation" aria-label="main navigation"]
   .container
     .navbar-brand
       = link_to root_path, class: 'navbar-item', data: { turbolinks: false }
-          = image_tag '/images/buildesk_logo.png', size: '112x28'
+          = image_tag('https://image.buildesk.app/images/buildesk_logo.png', size: '112x28')
       a.navbar-burger[role="button" aria-label="menu" aria-expanded="false" data-target="navMenu"]
         span[aria-hidden="true"]
         span[aria-hidden="true"]
         span[aria-hidden="true"] 
     #navMenu.navbar-menu
       .navbar-end
-        = link_to t('posts.index.title'), posts_path, class: 'navbar-item', data: { turbolinks: false }
+        = link_to 'デスク一覧', posts_path, class: 'navbar-item', data: { turbolinks: false }
         .navbar-item
           = link_to t('defaults.login'), login_path, class: 'button is-rounded is-primary is-inverted has-text-weight-semibold', data: { turbolinks: false }
 

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -11,6 +11,7 @@ header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation
         span[aria-hidden="true"] 
     #navMenu.navbar-menu
       .navbar-end
+        = link_to t('posts.index.title'), posts_path, class: 'navbar-item', data: { turbolinks: false }
         = link_to '新規投稿', new_post_path, class: 'navbar-item', data: { turbolinks: false }
         .navbar-item.has-dropdown.is-hoverable
           a.navbar-link

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -4,14 +4,14 @@ header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation
     .navbar-brand
       .navbar-item
         = link_to root_path, data: { turbolinks: false }
-          = image_tag('/images/buildesk_logo.png', size: '112x28')
+          = image_tag('https://image.buildesk.app/images/buildesk_logo.png', size: '112x28')
       a.navbar-burger[role="button" aria-label="menu" aria-expanded="false" data-target="navMenu"]
         span[aria-hidden="true"]
         span[aria-hidden="true"]
         span[aria-hidden="true"] 
     #navMenu.navbar-menu
       .navbar-end
-        = link_to t('posts.index.title'), posts_path, class: 'navbar-item', data: { turbolinks: false }
+        = link_to 'デスク一覧', posts_path, class: 'navbar-item', data: { turbolinks: false }
         = link_to '新規投稿', new_post_path, class: 'navbar-item', data: { turbolinks: false }
         .navbar-item.has-dropdown.is-hoverable
           a.navbar-link

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -15,7 +15,7 @@ main
         .column
           h1.title.is-3.has-text-weight-bold
             = t('.New Arrival')
-          .tile.is-ancestor
+          .tile.is-ancestor.columns
             - if @posts.present?
               = render @posts
           p.has-text-right

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -13,10 +13,73 @@ main
     section.section#new_arrival
       .columns.is-marginless
         .column
-          h1.title.is-3.has-text-weight-bold
+          h1.title.has-text-weight-bold
             = t('.New Arrival')
           .tile.is-ancestor.columns
             - if @posts.present?
               = render @posts
           p.has-text-right
             = link_to t('.show more'), posts_path
+
+      br
+      .columns.is-marginless
+        .column
+          h1.title.has-text-weight-bold
+            = 'カテゴリー'
+          .columns
+            .column.is-one-third.has-text-centered
+              = link_to category_path(Category.find(1).name)
+                .img-on-moji
+                  figure.image.is-3by1
+                    = image_tag('https://image.buildesk.app/images/engineer-image-bg.png')
+                  p.is-size-4.has-text-weight-bold.has-text-white
+                    | Engineer
+            .column.has-text-centered
+              = link_to category_path(Category.find(2).name)
+                .img-on-moji
+                  figure.image.is-3by1
+                    = image_tag('https://image.buildesk.app/images/writer-image-bg.png')
+                  p.is-size-4.has-text-weight-bold.has-text-white
+                    | Writer
+            .column.has-text-centered
+              = link_to category_path(Category.find(3).name)
+                .img-on-moji
+                  figure.image.is-3by1
+                    = image_tag('https://image.buildesk.app/images/mediacreator-image-bg.png')
+                  p.is-size-4.has-text-weight-bold.has-text-white
+                    | Media Creator
+
+      br
+      .columns.is-marginless
+        .column
+          h1.title.has-text-weight-bold
+            = "What's Buildesk"
+          .columns
+            .column.is-one-third.has-text-centered
+              .content
+                figure.image.is-16by9
+                  = image_tag('https://image.buildesk.app/images/desk_sample.jpg')
+                p.title.is-5.has-text-weight-semibold
+                  = '参考になるデスクを見つけよう'
+                p.is-size-7.has-text-grey-lighter
+                  = '見返したい投稿は保存可能。「エンジニア」「動画制作者」など、カテゴリー別でも探せます。'
+                button.button.is-primary
+                  = link_to 'デスク一覧', posts_path, class: 'has-text-white', data: { turbolinks: false }
+            .column.has-text-centered
+              .content
+                figure.image.is-16by9
+                  = image_tag('https://image.buildesk.app/images/item_sample.jpg')
+                p.title.is-5.has-text-weight-semibold
+                  = '気になるアイテムがすぐ分かる！'
+                p.is-size-7.has-text-grey-lighter
+                  = 'デスクに使われているアイテムのメーカーや価格が分かるので、調べる手間が省けます。アイテムの詳細ページでは、同じアイテムが使われている投稿一覧を見ることができます。'
+            .column.has-text-centered
+              .content
+                figure.image.is-16by9
+                  = image_tag('https://image.buildesk.app/images/photo_upload.jpg')
+                p.title.is-5.has-text-weight-semibold
+                  = '自分のデスクも登録しよう'
+                p.is-size-7.has-text-grey-lighter
+                  = 'デスク周りを一新したときや、My new gearしたときに。使っているアイテムも登録し、みんなにオススメを紹介しましょう。また、マイページではデスク遍歴を楽しむこともできます。'
+                button.button.is-primary
+                  = link_to '新規投稿', new_post_path, class: 'has-text-white', data: { turbolinks: false }

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -62,7 +62,7 @@ main
                 p.title.is-5.has-text-weight-semibold
                   = '参考になるデスクを見つけよう'
                 p.is-size-7.has-text-grey-lighter
-                  = '見返したい投稿は保存可能。「エンジニア」「動画制作者」など、カテゴリー別でも探せます。'
+                  = '見返したい投稿は保存可能。「エンジニア」「メディアクリエイター」など、カテゴリー別でも探せます。'
                 button.button.is-primary
                   = link_to 'デスク一覧', posts_path, class: 'has-text-white', data: { turbolinks: false }
             .column.has-text-centered

--- a/app/views/users/non_user.html.slim
+++ b/app/views/users/non_user.html.slim
@@ -12,7 +12,7 @@ main.columns.is-centered.is-marginless
                 .media
                   .media-left
                     figure.image.is-48x48
-                      = image_tag '/images/user_logo_blue.png', class: 'is-rounded'
+                      = image_tag 'https://image.buildesk.app/images/user_logo_blue.png', class: 'is-rounded'
                   .media-content
                     p.title.is-4.has-text-weight-bold
                       = 'Not found user'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -26,17 +26,12 @@ main.columns.is-centered.is-marginless
                     
               footer.card-footer id="user-link-id-#{@user.uuid}"
                 - if current_user == @user
-                  = link_to likes_posts_path, class: 'card-footer-item'
-                    span.icon-text
-                      i.fas.fa-heart
-                      span
-                        = ' Like'
                   = link_to bookmarks_posts_path, class: 'card-footer-item'
                     span.icon-text
                       i.fa.fa-bookmark
                       span
                         = ' List'
-                = link_to "https://twitter.com/share?url=#{request.url}&text=#{@user.name}のデスク集&hashtags=Buildesk,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
+                = link_to "https://twitter.com/share?url=#{request.url}&text=#{@user.name}のデスク＆アイテム集&hashtags=Buildesk,デスク周り,デスクツアー", title: 'Twitter', target: '_blank', class: 'card-footer-item'
                   span.icon-text
                     i.fab.fa-twitter
                     span

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -39,19 +39,24 @@ main.columns.is-centered.is-marginless
           .column.is-half
             p.title.has-text-weight-bold.is-4
               = "#{truncate(@user.name, length: 12)}のデスク遍歴"
-            .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
-              - if @posts.present?
+            - if @posts.present?
+              .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
                 = render partial: 'posts/post_image', collection: @posts
-              - else
+            - else
+              br
+              p.has-text-centered
                 = '投稿がありません'
+              br
             hr
             p.title.has-text-weight-bold.is-4
-              = "#{truncate(@user.name, length: 12)}のGear"
+              = "#{truncate(@user.name, length: 12)}のGears"
             p.subtitle.is-6
               | 投稿に紐づいたアイテム
-            .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
-              - if @posts.present?
+            - if @posts.present?
+              .columns.is-multiline.is-mobile.is-variable.is-1-desktop.is-1-mobile
                 = render partial: 'items/item_image', collection: @posts
-              - else
+            - else
+              br
+              p.has-text-centered
                 = '投稿がありません'
         br      

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,9 +28,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # 静的ファイルをfrontcloud経由で表示
-  config.asset_host = 'https://image.buildesk.app'
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -12,5 +12,6 @@ CarrierWave.configure do |config|
     region: 'ap-northeast-1'
   }
   config.fog_directory = 'buildesk-bucket'
-  # config.asset_host = 'https://image.buildesk.app'
+  config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
+  config.asset_host = 'https://image.buildesk.app'
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,15 +3,17 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
-    aws_secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key),
-    region: 'ap-northeast-1'
-  }
-  config.fog_directory = 'buildesk-bucket'
-  config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
-  config.asset_host = 'https://image.buildesk.app'
+  if Rails.env.production?
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
+      aws_secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key),
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory = 'buildesk-bucket'
+    config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
+    config.asset_host = 'https://image.buildesk.app'
+  end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -56,7 +56,7 @@ ja:
     likes:
       title: 'いいねした投稿'
     bookmarks:
-      title: 'ブックマークした投稿'
+      title: '保存した投稿'
   categories:
     show:
       title: 'カテゴリー別投稿一覧'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,7 +21,7 @@ ja:
   category:
     Engineer: 'エンジニア'
     MediaCreator: 'メディアクリエイター'
-    Writer: 'ライター / エディター'
+    Writer: 'ライター / イラストレーター'
     Designer: 'デザイナー / イラストレーター'
     Director: 'ディレクター / マーケター'
     Other: 'その他'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,8 @@ ja:
     bookmark: 'ブックマーク'
     unspecified: '指定なし'
     back: '戻る'
+    edit: '編集'
+    delete: '削除'
     message:
       created: "%{item}しました"
       not_created: "%{item}できません"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,124 +10,125 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_701_205_310) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_07_01_205310) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
-    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'item_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['item_id'], name: 'index_item_tags_on_item_id'
-    t.index ['post_id'], name: 'index_item_tags_on_post_id'
+  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_tags_on_item_id"
+    t.index ["post_id"], name: "index_item_tags_on_post_id"
   end
 
-  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name'
-    t.string 'image'
-    t.string 'price'
-    t.string 'rakuten_url'
-    t.string 'amazon_url'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'item_code', null: false
-    t.string 'maker'
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.string "price"
+    t.string "rakuten_url"
+    t.string "amazon_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "item_code", null: false
+    t.string "maker"
   end
 
-  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_likes_on_post_id'
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'area', default: 0, null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "area", default: 0, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.string 'uuid', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.string "uuid", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'bookmarks', 'posts'
-  add_foreign_key 'bookmarks', 'users'
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'item_tags', 'items'
-  add_foreign_key 'item_tags', 'posts'
-  add_foreign_key 'likes', 'posts'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "item_tags", "items"
+  add_foreign_key "item_tags", "posts"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,125 +10,124 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_205310) do
-
-  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+ActiveRecord::Schema.define(version: 20_210_701_205_310) do
+  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_bookmarks_on_post_id"
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
+    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["name"], name: "index_categories_on_name", unique: true
+  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['name'], name: 'index_categories_on_name', unique: true
   end
 
-  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body', null: false
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_comments_on_post_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "item_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["item_id"], name: "index_item_tags_on_item_id"
-    t.index ["post_id"], name: "index_item_tags_on_post_id"
+  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'item_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['item_id'], name: 'index_item_tags_on_item_id'
+    t.index ['post_id'], name: 'index_item_tags_on_post_id'
   end
 
-  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "name"
-    t.string "image"
-    t.string "price"
-    t.string "rakuten_url"
-    t.string "amazon_url"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "item_code", null: false
-    t.string "maker"
+  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'name'
+    t.string 'image'
+    t.string 'price'
+    t.string 'rakuten_url'
+    t.string 'amazon_url'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'item_code', null: false
+    t.string 'maker'
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_likes_on_post_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
+  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_likes_on_post_id'
+    t.index ['user_id'], name: 'index_likes_on_user_id'
   end
 
-  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.bigint "category_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
-    t.index ["category_id"], name: "index_post_categories_on_category_id"
-    t.index ["post_id"], name: "index_post_categories_on_post_id"
+  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.bigint 'category_id', null: false
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
+    t.index ['category_id'], name: 'index_post_categories_on_category_id'
+    t.index ['post_id'], name: 'index_post_categories_on_post_id'
   end
 
-  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "image", null: false
-    t.string "caption"
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_post_images_on_post_id"
+  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'image', null: false
+    t.string 'caption'
+    t.bigint 'post_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['post_id'], name: 'index_post_images_on_post_id'
   end
 
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "area", default: 0, null: false
-    t.index ["user_id"], name: "index_posts_on_user_id"
+  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'area', default: 0, null: false
+    t.index ['user_id'], name: 'index_posts_on_user_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "name", null: false
-    t.text "description"
-    t.string "image"
-    t.integer "role", default: 0, null: false
-    t.string "uuid", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'name', null: false
+    t.text 'description'
+    t.string 'image'
+    t.integer 'role', default: 0, null: false
+    t.string 'uuid', null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
   end
 
-  add_foreign_key "bookmarks", "posts"
-  add_foreign_key "bookmarks", "users"
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
-  add_foreign_key "item_tags", "items"
-  add_foreign_key "item_tags", "posts"
-  add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
-  add_foreign_key "post_categories", "categories"
-  add_foreign_key "post_categories", "posts"
-  add_foreign_key "post_images", "posts"
-  add_foreign_key "posts", "users"
+  add_foreign_key 'bookmarks', 'posts'
+  add_foreign_key 'bookmarks', 'users'
+  add_foreign_key 'comments', 'posts'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'item_tags', 'items'
+  add_foreign_key 'item_tags', 'posts'
+  add_foreign_key 'likes', 'posts'
+  add_foreign_key 'likes', 'users'
+  add_foreign_key 'post_categories', 'categories'
+  add_foreign_key 'post_categories', 'posts'
+  add_foreign_key 'post_images', 'posts'
+  add_foreign_key 'posts', 'users'
 end


### PR DESCRIPTION
## 概要

Closed #71 

- トップページ
  - 投稿一覧にアクセスしやすいようにリンクを設置
  - 投稿が4つ未満のときにレイアウトが崩れる現象を修正
  - 投稿カードの写真サイズを4x3に修正
  - 簡単な利用ガイドを追加

- 投稿一覧
  - 写真サイズを4x3に修正（モバイルではカテゴリーを非表示）

- 投稿詳細
  - いいね数の表示

- アプリ全体
  - フッターが上がってくる現象を解消

## チェックリスト

- [x] Lint のチェックをパスした

## コメント

現時点で即対応できなかったものは#71のissueに記載