### PR TITLE
Fix: 投稿画像の保存サイズを修正／OGPの設定を修正／GAの導入

### DIFF
--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -48,7 +48,7 @@ class PostsForm
       end
 
       items_params&.each do |item|
-        h_item = eval(item) # セキュリティホール的に非推奨らしい
+        h_item = eval(item) # evalmメソッドはセキュリティホール的に非推奨なので早急に修正
         new_item = Item.new(h_item)
 
         if Item.exists?(item_code: h_item[:item_code])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,8 +34,8 @@ module ApplicationHelper
   def default_og
     {
       site_name: :site,
-      title: :og_title,
-      description: :description,
+      title: :title,
+      description: t('top.index.og_description'),
       url: request.url,
       image: 'https://image.buildesk.app/images/app_ogp.png'
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,7 @@ module ApplicationHelper
       title: :title,
       description: t('top.index.og_description'),
       url: request.url,
-      image: 'https://image.buildesk.app/images/app_ogp.png'
+      image: 'https://image.buildesk.app/images/app_ogp_new.png'
     }
   end
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -38,13 +38,15 @@ class PostImageUploader < CarrierWave::Uploader::Base
   #   # do something
   # end
 
+  process resize_and_pad: [1200, 900, '#1a1a1a']
+
   # Create different versions of your uploaded files:
-  version :thumb do
-    process resize_to_fill: [1080, 1080]
+  version :thumb_1x1 do
+    process resize_to_fill: [400, 400]
   end
 
-  version :main do
-    process resize_and_pad: [1200, 900, '#1a1a1a']
+  version :thumb_4x3 do
+    process resize_and_pad: [640, 480, '#1a1a1a']
   end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/views/admin/posts/show.html.slim
+++ b/app/views/admin/posts/show.html.slim
@@ -42,7 +42,7 @@
             th[scope="row"]
               = t('activerecord.attributes.post.images')
             td
-              = image_tag @post.post_images.first.image_url(:main), size: '200x150'
+              = image_tag @post.post_images.first.image_url, size: '200x150'
           tr
             th[scope="row"]
               = t('activerecord.attributes.post.body')

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title'), og: { og_title: t('.og_title')}
+- set_meta_tags title: t('.title'), og: { title: t('.og_title', category: t("category.#{@category.name}"))}
 
 main.columns.is-centered.is-marginless
   .column.is-three-quarters

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title'), og: { og_title: t('.og_title') }
+- set_meta_tags title: t('.title'), og: { title: t('.og_title', item: @item.name) }
 
 main
   section.columns.is-centered.is-marginless

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,6 +1,16 @@
 doctype html
 html
   head
+    <!-- Google Tag Manager -->
+    javascript:
+      | (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      | new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      | j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      | 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      | })(window,document,'script','dataLayer','GTM-P7VT5QZ');
+
+    <!-- End Google Tag Manager -->
+    
     = csrf_meta_tags
     = csp_meta_tag
 
@@ -9,7 +19,13 @@ html
     = stylesheet_link_tag "https://unpkg.com/bulmaswatch/darkly/bulmaswatch.min.css"
     
     = display_meta_tags(default_meta_tags)
+
   body.site
+    <!-- Google Tag Manager (noscript) -->
+    noscript
+      iframe height="0" src="https://www.googletagmanager.com/ns.html?id=GTM-P7VT5QZ" style="display:none;visibility:hidden" width="0" 
+    <!-- End Google Tag Manager (noscript) -->
+
     - if logged_in?
       = render 'shared/header'
     - else

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -4,7 +4,7 @@
       = link_to post_path(post)
         .card-image
           figure.image
-            = image_tag post.post_images.first.image_url(:main), size: '1290x960', alt: 'post-img'
+            = image_tag post.post_images.first.image_url(:thumb_4x3), size: '1290x960', alt: 'post-img'
         .card-content
           .media
             .media-left

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -1,4 +1,4 @@
-.column.is-one-third-desktop
+.column.is-half-mobile.is-one-third-desktop
   .card
     div id="post-id-#{post_3col.id}"
       = link_to post_path(post_3col)

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -4,7 +4,7 @@
       = link_to post_path(post_3col)
         .card-image
           figure.image.is-4by3
-            = image_tag post_3col.post_images.first.image_url(:main), alt: 'post-img'
+            = image_tag post_3col.post_images.first.image_url(:thumb_4x3), alt: 'post-img'
         .card-content
           .media
             .media-left

--- a/app/views/posts/_post_image.html.slim
+++ b/app/views/posts/_post_image.html.slim
@@ -3,4 +3,4 @@
     .card-image
       figure.image
         = link_to post_path(post_image)
-          = image_tag post_image.post_images.first.image_url(:thumb), alt: 'post-img'
+          = image_tag post_image.post_images.first.image_url(:thumb_1x1), alt: 'post-img'

--- a/app/views/posts/bookmarks.html.slim
+++ b/app/views/posts/bookmarks.html.slim
@@ -7,6 +7,8 @@ main.columns.is-centered.is-marginless
         br
         p.title.has-text-weight-bold
           = t('.title')
+        p.subtitle.is-5
+          = '他のユーザーには公開されません'
         - if @bookmark_posts.present?
           .columns.is-multiline.is-mobile.is-variable.is-3-desktop.is-1-mobile
             = render partial: 'post_image', collection: @bookmark_posts

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title'), og: { og_title: t('.og_title')}
+- set_meta_tags title: t('.title'), og: { title: t('.og_title')}
 
 main.columns.is-centered.is-marginless
   .column.is-three-quarters

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title'), og: { og_title: t('.og_title', user: @post.user.name, data: l(@post.created_at, format: :simple)), description: @post.body, image: @post.post_images.first.image_url }
+- set_meta_tags title: t('.title'), og: { title: t('.og_title', user: @post.user.name, data: l(@post.created_at, format: :simple)), image: @post.post_images.first.image_url }
 
 section.hero.is-small
   .columns.is-centered.is-gapless

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -38,7 +38,7 @@ main
               .tile.is-vertical
             .tile.is-child
               figure.image.is-4by3
-                = image_tag @post.post_images.first.image_url(:main)
+                = image_tag @post.post_images.first.image_url
             / デスクトップ表示用コメント欄
             .tile.is-child.is-hidden-mobile
               p.title.has-text-weight-bold.is-5

--- a/app/views/public_pages/404.html.slim
+++ b/app/views/public_pages/404.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { og_title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags title: t('.404 Not Found')
 
 html.has-navbar-fixed-top
 header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation"]

--- a/app/views/public_pages/500.html.slim
+++ b/app/views/public_pages/500.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { og_title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags title: t('.500 Internal Server Error')
 
 html.has-navbar-fixed-top
 header.is-dark.navbar.is-fixed-top[role="navigation" aria-label="main navigation"]

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { og_title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags og: { title: t('.og_title'), description: t('.og_description') }
 
 section.hero.hero-1.is-medium[style="background-image: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.7)), url('https://image.buildesk.app/images/buildesk-main.jpg')"]
   .hero-body

--- a/app/views/top/privacy_policy.html.slim
+++ b/app/views/top/privacy_policy.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { og_title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags title: t('.title')
 
 main
   .container        

--- a/app/views/top/user_policy.slim
+++ b/app/views/top/user_policy.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { og_title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags title: t('.title')
 
 main
   .container        

--- a/app/views/users/non_user.html.slim
+++ b/app/views/users/non_user.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title'), og: { og_title: t('.og_title') }
+- set_meta_tags title: t('.title')
 
 main.columns.is-centered.is-marginless
   .column.is-three-quarters

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags title: t('.title', user: @user.name), og: { og_title: t('.og_title', user: @user.name) }
+- set_meta_tags title: t('.title', user: @user.name), og: { title: t('.og_title', user: @user.name) }
 
 main.columns.is-centered.is-marginless
   .column.is-three-quarters

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -177,8 +177,7 @@ Rails.application.config.sorcery.configure do |config|
   config.google.user_info_mapping = {
     email: 'email',
     name: 'name',
-    remote_image_url: 'picture',
-    uuid: 'email'
+    remote_image_url: 'picture'
   }
   config.google.scope = 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile'
   #

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -28,15 +28,20 @@ ja:
   top:
     index:
       og_title: '快適なデスク環境をビルドしよう'
-      og_description: 'Buildesk（ビルデスク）はデスク環境に特化した写真投稿サービスです。こだわりを持つリモートワーカーのデスクを参考にして、生産性アップにつなげよう。'
+      og_description: 'Buildesk（ビルデスク）はデスク環境に特化した写真投稿サービスです。みんなのデスクを参考にして、リモートワークの生産性アップにつなげよう。'
       New Arrival: '新着'
+    user_policy: 
+      title: '利用規約'
+    privacy_policy: 
+      title: 'プライバシーポリシー'
   users:
     new:
       title: 'ユーザー登録'
     show:
       title: "%{user}のデスク環境"
-      og_title: '%{user}のデスク集'
+      og_title: "%{user}のデスク＆アイテム集"
     non_user:
+      title: 'ユーザーが存在しません'
       Please enter the correct account name: '@正しいアカウント名を入力してください'
   user_sessions:
     new:
@@ -60,12 +65,14 @@ ja:
   categories:
     show:
       title: 'カテゴリー別投稿一覧'
+      og_title: '%{category}のデスク一覧'
   profiles:
     edit:
       title: 'プロフィール編集'
   items:
     show:
       title: 'アイテム詳細'
+      og_title: '%{item}'
   public_pages:
     404:
       404 Not Found: 'お探しのページは見つかりませんでした。'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,124 +10,125 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_717_124_428) do
-  create_table 'authentications', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+ActiveRecord::Schema.define(version: 2021_07_17_124428) do
+
+  create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'bookmarks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_bookmarks_on_post_id'
-    t.index ['user_id'], name: 'index_bookmarks_on_user_id'
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table 'categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['name'], name: 'index_categories_on_name', unique: true
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table 'comments', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body', null: false
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_comments_on_post_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'item_tags', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'item_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['item_id'], name: 'index_item_tags_on_item_id'
-    t.index ['post_id'], name: 'index_item_tags_on_post_id'
+  create_table "item_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_tags_on_item_id"
+    t.index ["post_id"], name: "index_item_tags_on_post_id"
   end
 
-  create_table 'items', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'name'
-    t.string 'image'
-    t.string 'price'
-    t.string 'rakuten_url'
-    t.string 'amazon_url'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'item_code', null: false
-    t.string 'maker'
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
+    t.string "image"
+    t.string "price"
+    t.string "rakuten_url"
+    t.string "amazon_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "item_code", null: false
+    t.string "maker"
   end
 
-  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_likes_on_post_id'
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'post_categories', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.bigint 'category_id', null: false
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[category_id post_id], name: 'index_post_categories_on_category_id_and_post_id', unique: true
-    t.index ['category_id'], name: 'index_post_categories_on_category_id'
-    t.index ['post_id'], name: 'index_post_categories_on_post_id'
+  create_table "post_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id", "post_id"], name: "index_post_categories_on_category_id_and_post_id", unique: true
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
-  create_table 'post_images', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'image', null: false
-    t.string 'caption'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_post_images_on_post_id'
+  create_table "post_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "image", null: false
+    t.string "caption"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'area', default: 0, null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "area", default: 0, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'name', null: false
-    t.text 'description'
-    t.string 'image'
-    t.integer 'role', default: 0, null: false
-    t.string 'uuid', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", null: false
+    t.text "description"
+    t.string "image"
+    t.integer "role", default: 0, null: false
+    t.string "uuid", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'bookmarks', 'posts'
-  add_foreign_key 'bookmarks', 'users'
-  add_foreign_key 'comments', 'posts'
-  add_foreign_key 'comments', 'users'
-  add_foreign_key 'item_tags', 'items'
-  add_foreign_key 'item_tags', 'posts'
-  add_foreign_key 'likes', 'posts'
-  add_foreign_key 'likes', 'users'
-  add_foreign_key 'post_categories', 'categories'
-  add_foreign_key 'post_categories', 'posts'
-  add_foreign_key 'post_images', 'posts'
-  add_foreign_key 'posts', 'users'
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
+  add_foreign_key "item_tags", "items"
+  add_foreign_key "item_tags", "posts"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
+  add_foreign_key "post_images", "posts"
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## 概要

- ページ読み込み改善のために投稿された画像の保存サイズを調整
- マーケのためにGoogleタグマネージャー経由でGoogleアナリティクスを導入
- OGP出力のための設定を修正

Closed #89 
Closed #88 

## チェックリスト

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした

## コメント

- OGPに関しては本番環境で確認してからissueを閉じる