### PR TITLE
Fix: swiper.jsの挙動を修正

### DIFF
--- a/app/javascript/packs/swiper.js
+++ b/app/javascript/packs/swiper.js
@@ -1,6 +1,13 @@
-const swiper = new Swiper('.swiper-container', {
-  pagination: {
-    el: '.swiper-pagination',
-		clickable: true
-  },
+$(document).on('turbolinks:load', function() {
+
+  const slideLength = document.querySelectorAll('.swiper-container .swiper-slide').length
+
+  if (slideLength > 1) {
+    const swiper = new Swiper('.swiper-container', {
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true
+      },
+    });
+  };
 });


### PR DESCRIPTION
## 概要

- ページ切り替え時にswiper.jsを作動させるため、turbolinksをoff
- 複数枚の時だけswiper.jsを作動させるため、枚数をカウントするロジックを追加

## 影響範囲

- 投稿詳細ページの画像表示部分

## チェックリスト
- [ ] Lint のチェックをパスした