### PR TITLE
Fix: 投稿画像のサイズ変更に伴ったファイル名の修正

### DIFF
--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -7,8 +7,8 @@ class PostImage < ApplicationRecord
 
   def destroy_image_s3
     image.remove!
-    image.thumb.remove!
-    image.main.remove!
+    image.thumb_1x1.remove!
+    image.thumb_4x3.remove!
   rescue Excon::Errors::Error => e
     puts 'Something gone wrong'
     false


### PR DESCRIPTION
## 概要

-  s3の画像を削除する際にファイル形式を指定しなければいけないので、変更したファイル名を指定