### PR TITLE
Fix: プロフ更新機能のバリデーションを修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 50 } # Twitterに準拠
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-  validates :email, uniqueness: { case_sensitive: true }, format: { with: VALID_EMAIL_REGEX }
+  validates :email, uniqueness: { case_sensitive: true }, format: { with: VALID_EMAIL_REGEX }, on: :create
   validates :password, length: { in: 8..30 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -7,7 +7,7 @@ ExceptionNotification.configure do |config|
 
   # Adds a condition to decide when an exception must be ignored or not.
   # The ignore_if method can be invoked multiple times to add extra conditions.
-  config.ignore_if do |_exception, _options|
+  config.ignore_if do
     !Rails.env.production?
   end
 


### PR DESCRIPTION
## 概要

- メアドのバリデーションをupdateで作動しないようにonオプションを設定
  - プロフ更新時に不必要なため
- エラー通知を本番環境のみに届くように修正