### PR TITLE
Add: 投稿カードに表示する情報を変更／その他

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::ItemsController < ApplicationController
     if params[:keyword]
       results = RakutenWebService::Ichiba::Product.search(
         keyword: params[:keyword],
-        hits: 10
+        hits: 18
       )
       results.each do |result|
         item = {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :post_set, only: %i[edit update destroy]
 
   def index
-    @posts = Post.all.includes(:user, :post_images, :categories).order(created_at: :desc)
+    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :post_set, only: %i[edit update destroy]
 
   def index
-    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments).order(created_at: :desc)
+    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments, :item_tags).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,7 +2,7 @@ class TopController < ApplicationController
   skip_before_action :require_login, only: %i[index user_policy privacy_policy]
 
   def index
-    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments).order(created_at: :desc).limit(4)
+    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments, :item_tags).order(created_at: :desc).limit(4)
     @categories = Category.select('name')
   end
 

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -2,7 +2,8 @@ class TopController < ApplicationController
   skip_before_action :require_login, only: %i[index user_policy privacy_policy]
 
   def index
-    @posts = Post.all.includes(:user, :post_images, :categories).order(created_at: :desc).limit(4)
+    @posts = Post.all.includes(:user, :post_images, :categories, :likes, :comments).order(created_at: :desc).limit(4)
+    @categories = Category.select('name')
   end
 
   def user_policy; end

--- a/app/forms/posts_form.rb
+++ b/app/forms/posts_form.rb
@@ -23,6 +23,7 @@ class PostsForm
 
   validate :image_content_type
   validate :image_size
+  validate :image_count
 
   delegate :persisted?, to: :@post
 
@@ -122,5 +123,9 @@ class PostsForm
     images&.each do |image|
       errors.add(:images, 'は5MB以下のファイルまでアップロードできます') if image.size > 5.megabytes
     end
+  end
+
+  def image_count
+    errors.add(:images, 'は5枚までアップロードできます') if images.count >= 6
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,9 @@ module ApplicationHelper
       site: t('site.name'),
       reverse: true,
       separator: '|',
+      site: t('site.name'),
+      description: t('site.description'),
+      keyword: 'リモートワーク,デスクワーク,デスクワーカー,デスク環境,デスク周り,mynewgear,desktour,deskphoto',
       og: default_og,
       twitter: default_twitter_card,
       icon: [

--- a/app/views/api/v1/items/_item_list.html.slim
+++ b/app/views/api/v1/items/_item_list.html.slim
@@ -1,8 +1,8 @@
-- items.first(10).each_with_index do |item, index|
+- items.each_with_index do |item, index|
   .column.is-half-mobile.is-one-third-desktop.item
     .card id="search-id-#{index}"
       .card-image
-        figure.image.is-1by1
+        figure.image.is-5by4
           = image_tag(item[:image])
       .card-content
         .content

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -22,6 +22,8 @@
             | 画像形式: JPEG/PNG
           dt.has-text-grey-lighter.is-size-7.has-text-weight-semibold
             | 推奨サイズ: 4x3
+          dt.has-text-grey-lighter.is-size-7.has-text-weight-semibold
+            | ファイルサイズ: 5MB, 5枚まで可能
       .column
         .media-content
           .media-right
@@ -69,7 +71,7 @@
           dt.help.has-text-grey-lighter.is-size-7
             | アイテムは5つまで選択可能です*
           dt.has-text-grey-lighter.is-size-7
-            | 投稿後に選択・削除することはできません*
+            | 投稿後に追加・削除することはできません*
 
       = f.hidden_field 'items1', multiple: true
       = f.hidden_field 'items2', multiple: true

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -13,7 +13,7 @@
             .media-content
               p.title.is-6.has-text-weight-semibold
                 = truncate(post.user.name, length: 12)
-              p.subtitle.is-6
+              p.subtitle.is-7
                 span.icon-text
                   span.icon
                     i

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -14,7 +14,19 @@
               p.title.is-6.has-text-weight-semibold
                 = truncate(post.user.name, length: 12)
               p.subtitle.is-6
-                = l post.created_at, format: :short
+                span.icon-text
+                  span.icon
+                    i
+                      i.far.fa-heart
+                  span 
+                    = post.likes.size
+                    | &ensp;
+                  span.icon
+                    i
+                      i.far.fa-comment
+                  span 
+                    = post.comments.size
+
             .media-right
               span.tag.is-light.is-rounded
                 .is-6

--- a/app/views/posts/_post.html.slim
+++ b/app/views/posts/_post.html.slim
@@ -17,15 +17,21 @@
                 span.icon-text
                   span.icon
                     i
-                      i.far.fa-heart
+                      i.fa.fa-heart
                   span 
                     = post.likes.size
                     | &ensp;
                   span.icon
                     i
-                      i.far.fa-comment
+                      i.fa.fa-comment
                   span 
                     = post.comments.size
+                    | &ensp;
+                  span.icon
+                    i
+                      i.fa.fa-tags
+                  span
+                    = post.item_tags.size
 
             .media-right
               span.tag.is-light.is-rounded

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -8,24 +8,29 @@
         .card-content
           .media
             .media-left
-              figure.image.is-32x32
+              figure.image.is-24x24
                 = image_tag post_3col.user.image_url(:thumb), class: 'is-rounded'
             .media-content
               p.title.is-6.has-text-weight-semibold
                 = truncate(post_3col.user.name, length: 10)
               p.subtitle.is-7
-                span.icon-text
-                  span.icon
-                    i
-                      i.far.fa-heart
-                  span 
-                    = post_3col.likes.size
-                    | &ensp;
-                  span.icon
-                    i
-                      i.far.fa-comment
-                  span 
-                    = post_3col.comments.size
+                small
+                  span.icon-text
+                    span.icon
+                      i
+                        i.fa.fa-heart
+                    span 
+                      = post_3col.likes.size
+                    span.icon
+                      i
+                        i.fa.fa-comment
+                    span 
+                      = post_3col.comments.size
+                    span.icon
+                      i
+                        i.fa.fa-tags
+                    span
+                      = post_3col.item_tags.size
             .media-right
               span.tag.is-light.is-rounded.is-hidden-mobile
                 .is-6

--- a/app/views/posts/_post_3col.html.slim
+++ b/app/views/posts/_post_3col.html.slim
@@ -14,7 +14,18 @@
               p.title.is-6.has-text-weight-semibold
                 = truncate(post_3col.user.name, length: 10)
               p.subtitle.is-7
-                = l post_3col.created_at, format: :short
+                span.icon-text
+                  span.icon
+                    i
+                      i.far.fa-heart
+                  span 
+                    = post_3col.likes.size
+                    | &ensp;
+                  span.icon
+                    i
+                      i.far.fa-comment
+                  span 
+                    = post_3col.comments.size
             .media-right
               span.tag.is-light.is-rounded.is-hidden-mobile
                 .is-6

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -4,6 +4,9 @@ footer.footer
       strong © 2021 
       strong = link_to 'Buildesk', root_path, class: 'has-text-light'
     
-    p = link_to '利用規約', user_policy_path, class: 'has-text-light'
-    p = link_to 'プライバシーポリシー', privacy_policy_path, class: 'has-text-light'
-    p = link_to 'お問い合わせ', 'https://docs.google.com/forms/d/e/1FAIpQLSc3nv7546WfYCWEcRd53IdtfS4DKkyORGAEEAPr-QUggrWXuw/viewform', class: 'has-text-light'
+    p
+      = link_to '利用規約', user_policy_path, class: 'has-text-light'
+      | &ensp;
+      = link_to 'プライバシーポリシー', privacy_policy_path, class: 'has-text-light'
+      | &ensp;
+      = link_to 'お問い合わせ', 'https://docs.google.com/forms/d/e/1FAIpQLSc3nv7546WfYCWEcRd53IdtfS4DKkyORGAEEAPr-QUggrWXuw/viewform', class: 'has-text-light'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -30,9 +30,9 @@ nav.navbar.is-dark.is-fixed-bottom[role="navigation"]
       p.is-size-7
         | Home
     = link_to posts_path, class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
-      i.fa.fa-bolt
+      i.fas.fa-search
       p.is-size-7
-        | New
+        | Search
     = link_to new_post_path, class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
       i.fa.fa-plus-square
       p.is-size-7
@@ -40,7 +40,7 @@ nav.navbar.is-dark.is-fixed-bottom[role="navigation"]
     = link_to bookmarks_posts_path, class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
       i.fa.fa-bookmark
       p.is-size-7
-        | List
+        | Keep
     = link_to user_path(current_user), class: 'navbar-item is-expanded is-block has-text-centered', data: { turbolinks: false } do
       i.fa.fa-user
       p.is-size-7

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -28,21 +28,21 @@ main
             = 'カテゴリー'
           .columns
             .column.is-one-third.has-text-centered
-              = link_to category_path(Category.find(1).name)
+              = link_to category_path(@categories[0].name)
                 .img-on-moji
                   figure.image.is-3by1
                     = image_tag('https://image.buildesk.app/images/engineer-image-bg.png')
                   p.is-size-4.has-text-weight-bold.has-text-white
                     | Engineer
             .column.has-text-centered
-              = link_to category_path(Category.find(2).name)
+              = link_to category_path(@categories[2].name)
                 .img-on-moji
                   figure.image.is-3by1
                     = image_tag('https://image.buildesk.app/images/writer-image-bg.png')
                   p.is-size-4.has-text-weight-bold.has-text-white
                     | Writer
             .column.has-text-centered
-              = link_to category_path(Category.find(3).name)
+              = link_to category_path(@categories[1].name)
                 .img-on-moji
                   figure.image.is-3by1
                     = image_tag('https://image.buildesk.app/images/mediacreator-image-bg.png')

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags og: { title: t('.og_title'), description: t('.og_description') }
+- set_meta_tags title: t('top.index.title'), og: { title: t('.og_title'), description: t('.og_description') }
 
 section.hero.hero-1.is-medium[style="background-image: linear-gradient(rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.7)), url('https://image.buildesk.app/images/buildesk-main.jpg')"]
   .hero-body

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
       not_deleted: "%{item}を削除できません"
   site:
     name: 'Buildesk（ビルデスク）'
+    description: 'Buildesk（ビルデスク）はデスク環境に特化した写真投稿サービスです。みんなのデスクを参考にして、リモートワークの生産性アップにつなげよう。'
   category:
     Engineer: 'エンジニア'
     MediaCreator: 'メディアクリエイター'
@@ -29,6 +30,7 @@ ja:
     Other: 'その他'
   top:
     index:
+      title: 'トップページ'
       og_title: '快適なデスク環境をビルドしよう｜Buildesk'
       og_description: 'Buildesk（ビルデスク）はデスク環境に特化した写真投稿サービスです。みんなのデスクを参考にして、リモートワークの生産性アップにつなげよう。'
       New Arrival: '新着'
@@ -77,8 +79,10 @@ ja:
       og_title: '%{item}｜Buildesk'
   public_pages:
     404:
+      title: '404 Not Found'
       404 Not Found: 'お探しのページは見つかりませんでした。'
     500:
+      title: 'サーバーエラー'
       500 Internal Server Error: 'サーバーエラーが発生しました。'
   time:
     formats:


### PR DESCRIPTION
## 概要

- 投稿カードにいいね数、コメント数、アイテムタグ数を表示
- フッターの幅が狭くなるように文字を横並びに修正
- SEO対策のmetaタグを設定
- 投稿枚数のバリデーションを設定し、ユーザーへのアナウンスを追加
- スマホナビのアイコンとタイトルを明瞭化のため変更
- アイテム検索のヒット数を18件に引き上げ

Closed #108 

- [ ] i18nの日本語化設定をした
- [ ] Lint のチェックをパスした

## コメント

テスト書く